### PR TITLE
Go Module migration + extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This simple application allow the user to concatenate files specified on a json 
 
 ## TODO
 
-- Allow the user to specify all the params (input file, output file, base path for the target files...)
 - Add more testing to the other methods in main
+- Find a way to disable the logger when running the all the tests
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/geektimus/sql-merger
+
+require github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
+github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -10,14 +10,14 @@ import (
 	"os"
 )
 
-type HLTPTransformationWrapper struct {
+type Wrapper struct {
 	Jars           []string `json:"jars"`
 	Schema         []string `json:"schema"`
 	Transformation []string `json:"transformation"`
 }
 
-type HLTPDescriptor struct {
-	Wrapper HLTPTransformationWrapper `json:"transform"`
+type Descriptor struct {
+	Wrapper Wrapper `json:"transform"`
 }
 
 func main() {
@@ -44,8 +44,8 @@ func main() {
 // parseJsonToDescriptor receives a Json file with some configuration and
 // it returns a descriptor containing all the information required to
 // concatenate the files (in order)
-func parseJsonToDescriptor(jsonFile string) (HLTPDescriptor, error) {
-	var descriptor HLTPDescriptor
+func parseJsonToDescriptor(jsonFile string) (Descriptor, error) {
+	var descriptor Descriptor
 
 	// Open our inputJsonFile
 	inputJsonFile, err := os.Open(jsonFile)
@@ -71,7 +71,7 @@ func parseJsonToDescriptor(jsonFile string) (HLTPDescriptor, error) {
 
 // concatenateFiles receives a descriptor with the location of the files and
 // it concatenates all of them on the outputFileName
-func concatenateFiles(descriptor HLTPDescriptor, basePathForFiles string, outputFileName string) error {
+func concatenateFiles(descriptor Descriptor, basePathForFiles string, outputFileName string) error {
 
 	out, err := os.OpenFile(outputFileName, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ type Wrapper struct {
 	Transformation []string `json:"transformation"`
 }
 
+func (w Wrapper) flat() []string {
+	return append(w.Schema, w.Transformation...)
+}
+
 type Descriptor struct {
 	Wrapper Wrapper `json:"transform"`
 }
@@ -80,9 +84,8 @@ func concatenateFiles(descriptor Descriptor, basePathForFiles string, outputFile
 	defer out.Close()
 
 	wrapper := descriptor.Wrapper
-	paths := append(wrapper.Schema, wrapper.Transformation...)
 
-	for _, e := range paths {
+	for _, e := range wrapper.flat() {
 		err := concatenateFile(basePathForFiles+"/"+e, out)
 		if err != nil {
 			return err

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/sirupsen/logrus"
 	"os"
 	"testing"
 )
@@ -52,6 +53,7 @@ func TestInvalidJsonToDescriptor(t *testing.T) {
 }
 
 func TestConcatenateFiles(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
 	outputFileName := "test-output.txt"
 	descriptor, _ := parseJsonToDescriptor("testdata/workflow.json")
 	err := concatenateFiles(descriptor, "testdata", outputFileName)


### PR DESCRIPTION
This PR contains:

- Upgrade the app to go modules (research purposes)
- Rename main objects with generic versions of the base names.
- Add logrus as a better alternative for the logs.
- Add helper functions for the Wrapper
